### PR TITLE
Adding a link to open the ergopay: URI in external app handler

### DIFF
--- a/src/components/BigQRCode.js
+++ b/src/components/BigQRCode.js
@@ -48,6 +48,7 @@ export default class BigQRCode extends React.Component {
             <Fragment>
                 <div className="m-1 d-flex flex-column">
                     <span
+                        className='m-1 d-flex justify-content-center'
                         onClick={this.zoomInOut}
                         data-tip
                         data-for="BigQRCode"
@@ -61,6 +62,9 @@ export default class BigQRCode extends React.Component {
                     <ReactTooltip id="BigQRCode" html={true} delayShow={400}>
                         Click to zoom
                     </ReactTooltip>
+                    <div className="m-1 d-flex justify-content-center">
+                        <a className=' btn btn-outline-info' href={this.props.QRCodeTx} target='_blank' rel='noreferrer' >Open wallet app</a>
+                    </div>
                 </div>
             </Fragment >
         )


### PR DESCRIPTION
This allows the OS (android or others) to process the `ergopay:....` URI by clicking the link to open in external app. This may be supported by desktop application wallets in the future, and presents possible SAFEW mobile extension functionality in the future.

Some people already use full chrome extensions in their mobile browsers today, this will support them to use ErgoPay without scanning one phone from another phone.